### PR TITLE
[Enhancement] - Add join table messages_users for group messages 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
     database_cleaner-active_record (2.2.0)
@@ -151,6 +152,11 @@ GEM
     nokogiri (1.17.1-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.9)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     public_suffix (6.0.1)
     puma (5.6.9)
       nio4r (~> 2.0)
@@ -285,6 +291,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)
+  pry-rails
   puma (~> 5.0)
   rails (= 6.1.7.10)
   rspec-rails

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ TwilioService
 
 # Data Models
 User
-  - has many + belongs to Conversations
+  - has_and_belongs_to_many to Conversations
   - has many messages
   *** has_and_belongs_to_many => association tells Rails to look for the join table
 
 Conversation
-  - has many + belongs to Users
+  - has_and_belongs_to_many to Users
   - has many Messages
   *** has_and_belongs_to_many => association tells Rails to look for the join table
 
@@ -50,6 +50,30 @@ Message
   - belongs to User
   - belongs to Conversation
 
+Messages_Users
+  - Join Table
+  - has_and_belongs_to_many messages
+  - has_and_belongs_to_many :recipients, class_name: 'User'
+  *** has_and_belongs_to_many => association tells Rails to look for the join table
+
+# Validations
+User
+  - Needs a unique username
+  - Needs a unique email address
+  - Needs a unique phone number
+
+Conversation
+  - Needs a name for the conversation
+
+User_Conversation
+  - Needs a unique pair => [:user_id, :conversation_id]
+
+Message
+  - Needs a body, 300 characters limit
+  - Needs a sender/user_id
+
+Messages_Users
+  - Needs a unique pair => [:message_id, :recipient_id]
 
 # Next Steps...
 - Test Twilio API connection
@@ -60,7 +84,14 @@ Message
 - validate email address with method/regular expression
 - validate phone number with method/regular expression
 - Group Messages: need to make single message per each user
-- db migration on Message table, receipient_id => array of user_ids
 - Permissions => Admin, User
 - Add OAuth 2 to User model
 - Frontend lay out => Hotwire? or React?
+- DRY up test suite, let's make more fixtures
+- Touch ups in test suite => Let's do some linting
+- Touch ups in app => Let's do some linting
+
+# Troublshooting + Testing
+Run tests in local environment
+  - RAILS_ENV=test bundle exec rspec
+  - RAILS_ENV=test bundle exec rspec spec/models/<YOUR TARGET TEST FILE>.rb

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,16 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :conversation
+  has_and_belongs_to_many :recipients, class_name: 'User'
 
   validates :body, presence: true, length: { maximum: 300 }
   validates :user, presence: true
+  validate :must_have_at_least_one_recipient
+
+  def must_have_at_least_one_recipient
+    if recipients.empty?
+      errors.add(:recipients, "must have at least one recipient")
+      Rails.logger.warn("Message #{self.id} validation failed: no recipients provided")
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_and_belongs_to_many :conversations
-  has_many :messages
+  has_and_belongs_to_many :messages
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true

--- a/db/migrate/20241229161617_create_join_table_messages_users.rb
+++ b/db/migrate/20241229161617_create_join_table_messages_users.rb
@@ -1,0 +1,13 @@
+class CreateJoinTableMessagesUsers < ActiveRecord::Migration[6.1]
+  def up
+    create_join_table :messages, :users do |t|
+      t.index :message_id
+      t.index :user_id
+      t.index [:message_id, :user_id], unique: true 
+    end
+  end
+
+  def down
+    drop_join_table :messages, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_29_050238) do
+ActiveRecord::Schema.define(version: 2024_12_29_161617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,14 @@ ActiveRecord::Schema.define(version: 2024_12_29_050238) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "messages_users", id: false, force: :cascade do |t|
+    t.bigint "message_id", null: false
+    t.bigint "user_id", null: false
+    t.index ["message_id", "user_id"], name: "index_messages_users_on_message_id_and_user_id", unique: true
+    t.index ["message_id"], name: "index_messages_users_on_message_id"
+    t.index ["user_id"], name: "index_messages_users_on_user_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -28,14 +28,15 @@ RSpec.describe Conversation, type: :model do
   end
 
   it "can have messages" do
-    user = User.create!(name: "John Doe", email: "john@example.com", phone_number: "1234567890")
+    user1 = User.create!(name: 'John Doe', email: 'john@example.com', phone_number: '1234567890')
+    user2 = User.create!(name: 'Pasta Master', email: 'ilovepasta@pasta.com', phone_number: '+1234567890')
     conversation = Conversation.create!(name: "General Chat")
-    conversation.users << user
-    message = Message.create!(conversation: conversation, body: "Hello World", user: user)
+    conversation.users << user1
+    message = Message.create!(conversation: conversation, body: "Hello World", user: user1, recipients: [user2])
     
     expect(conversation.messages).to include(message)
     expect(message.conversation).to eq(conversation)
-    expect(message.user).to eq(user)
+    expect(message.user).to eq(user1)
   end
 
   it "does not add the same user twice" do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Message, type: :model do
     it { should validate_presence_of(:body) }
     it { should validate_length_of(:body).is_at_most(300) }
     it { should validate_presence_of(:user) }
+    it { should have_and_belong_to_many(:recipients).class_name('User') }
 
     it "is invalid if the body exceeds 300 characters" do
       user = User.create!(name: "John Doe", email: "john@example.com", phone_number: "1234567890")
@@ -17,9 +18,10 @@ RSpec.describe Message, type: :model do
     end
 
     it "is valid if the body is 300 characters or fewer" do
-      user = User.create!(name: "John Doe", email: "john@example.com", phone_number: "1234567890")
-      conversation = Conversation.create!(name: "General Chat")
-      message = Message.new(body: "a" * 300, user: user, conversation: conversation)
+      user1 = User.create!(name: 'John Doe', email: 'john@example.com', phone_number: '+1234567890')
+      user2 = User.create!(name: 'Gary', email: 'gary23@email.com', phone_number: '+12345678')
+      conversation = Conversation.create!(name: 'General Chat')
+      message = Message.new(body: 'a' * 300, user: user1, recipients: [user2]  , conversation: conversation)
 
       expect(message.valid?).to eq(true)
     end
@@ -36,5 +38,24 @@ RSpec.describe Message, type: :model do
       expect(message.valid?).to be(false)
       expect(message.errors[:conversation]).to include("must exist")
     end
+
+    it "is valid with a body and recipients" do
+      user1 = User.create!(name: "John Doe", email: "john@example.com", phone_number: "1234567890")
+      user2 = User.create!(name: "Jane Doe", email: "jane@example.com", phone_number: "9876543210")
+      conversation = Conversation.create!(name: "General Chat")
+      message = Message.new(body: "Hello", user: user1, conversation: conversation, recipients: [user2])
+  
+      expect(message).to be_valid
+    end
+
+    it "is invalid without recipients" do
+      user = User.create!(name: "John Doe", email: "john@example.com", phone_number: "1234567890")
+      conversation = Conversation.create!(name: "General Chat")
+      message = Message.new(body: "Hello", user: user, conversation: conversation)
+  
+      expect(message).not_to be_valid
+      expect(message.errors[:recipients]).to include("must have at least one recipient")
+    end
+
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-
+require 'pry'
 RSpec.describe User, type: :model do
 
   it "is valid with a name and email" do
@@ -36,7 +36,7 @@ RSpec.describe User, type: :model do
 
   # Test associations
   it { should have_and_belong_to_many(:conversations) }
-  it { should have_many(:messages) }
+  it { should have_and_belong_to_many(:messages) }
 
   # Test HABTM relationship (User can be added to a conversation)
   it "can be added to a conversation" do
@@ -49,13 +49,17 @@ RSpec.describe User, type: :model do
   end
 
   # Test messages association
-  it "can have messages" do
-    user = User.create!(name: "John Doe", email: "john@example.com", phone_number: "1234567890")
+  it "can have messages + recipients" do
+    user1 = User.create!(name: "John Doe", email: "john@example.com", phone_number: "1234567890")
+    user2 = User.create!(name: "Jimmy Dobber", email: "jimmy_d@example.com", phone_number: "1224567890")
+  
     conversation = Conversation.create!(name: "General Chat")
-    conversation.users << user
-    message = Message.create!(conversation: conversation, body: "Hello World", user: user)
-    
-    expect(user.messages).to include(message)
-    expect(message.user).to eq(user)
+    conversation.users << user1
+    conversation.users << user2
+  
+    message = Message.create!(conversation: conversation, body: "Hello World", user: user1, recipients: [user2])
+  
+    expect(message.recipients).to include(user2)
+    expect(message.user).to eq(user1)
   end
 end


### PR DESCRIPTION
**Why?**
- I want to send group SMS messages

**What happened?**
- Wrote a db migration for the messages_users join table + composite index
- refactored #create method + added 2 helper methods for SMS calls + grabbing recipient user IDs
- refactored messages controller for recipients
- updated Rspec tests to reflect new changes
- updated message modal association for recipients/users 
- added validation + logging on messages, we now need at least 1 recipient/user to create a message
- updated user modal association => has_and_belongs_to_many  for messages
- updated readme
- Added pry gem for debugging

**Notes**
- n/a


