### PR TITLE
[Enhancement] - Setup test messaging  for Twilio Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,7 @@ Messages_Users
 Run tests in local environment
   - RAILS_ENV=test bundle exec rspec
   - RAILS_ENV=test bundle exec rspec spec/models/<YOUR TARGET TEST FILE>.rb
+
+Using Phone Number in Twilio
+  - E.164 is the international telephone numbering plan that ensures each device on the PSTN has globally unique number.
+  - Vist here: https://www.twilio.com/docs/glossary/what-e164

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -20,4 +20,20 @@ class TwilioService
       raise
     end
   end
+
+  def send_test_message
+    # Use a valid phone number for testing.
+    test_phone_number = ENV['TEST_PHONE_NUMBER']
+    if test_phone_number.blank?
+      Rails.logger.error "Test phone number is missing in environment variables."
+      return
+    end
+
+    send_message(
+      from: ENV['TWILIO_PHONE_NUMBER'],
+      to: test_phone_number,
+      body: 'TEST MESSAGE: This is a test message from your Twilio integration.'
+    )
+  end
+
 end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe TwilioService, type: :service do
+  let(:twilio_service) { TwilioService.new }
+  let(:test_phone_number) { ENV['TEST_PHONE_NUMBER'] }
+
+  before do
+    # This is a Stub, Twilio client does not actually try to send an SMS here
+    allow(twilio_service).to receive(:send_message).and_return(double('Message', sid: 'fake_sid'))
+  end
+
+  describe '#send_test_message' do
+    context 'when the test phone number is set in the environment' do
+      it 'sends a test message' do
+        expect(twilio_service).to receive(:send_message).with(
+          from: ENV['TWILIO_PHONE_NUMBER'],
+          to: test_phone_number,
+          body: 'TEST MESSAGE: This is a test message from your Twilio integration.'
+        )
+
+ 
+        twilio_service.send_test_message
+      end
+    end
+
+    context 'when the test phone number is missing' do
+      before do
+        ENV['TEST_PHONE_NUMBER'] = nil
+      end
+
+      it 'does not send a message and logs an error' do
+        expect(Rails.logger).to receive(:error).with("Test phone number is missing in environment variables.")
+
+        twilio_service.send_test_message
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why?
- Need a way to test a Twilio connection

What?
- Setup to pass a test number via ENV global
- Created a Rspec test with Mock for our Twilio Service 
- Updated Readme

Notes:
- Waiting on Number Verification from Twilio
-  Takes 3-5 days