### PR TITLE
[Enhancement] - Add rate limiting to Twilio Service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '3.0.2'
 gem 'rails', '6.1.7.10'
 # gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 gem 'pg', '~> 1.1' # Use postgresql for Active Record
+gem 'redis'
 gem 'puma', '~> 5.0'
 gem 'sass-rails', '>= 6'
 gem 'webpacker', '>= 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
     crass (1.0.6)
     database_cleaner-active_record (2.2.0)
       activerecord (>= 5.a)
@@ -198,6 +199,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.23.0)
+      connection_pool
     regexp_parser (2.9.3)
     rexml (3.3.9)
     rspec-core (3.13.2)
@@ -294,6 +299,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (= 6.1.7.10)
+  redis
   rspec-rails
   sass-rails (>= 6)
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -76,14 +76,11 @@ Messages_Users
   - Needs a unique pair => [:message_id, :recipient_id]
 
 # Next Steps...
-- Test Twilio API connection
-- Add rate limiting to Twilio API connection
-- Write a mock test to check Twilio API connection, Webmock
-- Setup redis
+- Test Twilio API connection (waiting on Twilio)
+- Setup redis for ActionCable
 - Add ActionCable + Channels for real time messaging
 - validate email address with method/regular expression
 - validate phone number with method/regular expression
-- Group Messages: need to make single message per each user
 - Permissions => Admin, User
 - Add OAuth 2 to User model
 - Frontend lay out => Hotwire? or React?

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -5,16 +5,28 @@ class TwilioService
     @client = Twilio::REST::Client.new(
       ENV['TWILIO_ACCOUNT_SID'], 
       ENV['TWILIO_AUTH_TOKEN']
-      )
+    )
+    @redis = Redis.new
+    @test_mode = ENV['RATE_LIMIT_TEST_MODE'] == 'true'
   end
 
   def send_message(from: ENV['TWILIO_PHONE_NUMBER'],to:, body:)
     begin
-      @client.messages.create(
-        from: from,
-        to: to,
-        body: body
-      )
+
+      if rate_limited?(to)
+        raise 'Rate limit exceeded'
+      end
+
+      unless @test_mode
+        # Only make the actual API call if we are not in test mode
+        @client.messages.create(
+          from: from,
+          to: to,
+          body: body
+        )
+      end
+
+      record_sent_message(to)
     rescue Twilio::REST::RestError => e
       Rails.logger.error "Error failed to send message: #{e.message}"
       raise
@@ -34,6 +46,23 @@ class TwilioService
       to: test_phone_number,
       body: 'TEST MESSAGE: This is a test message from your Twilio integration.'
     )
+  end
+
+  private
+
+  def rate_limited?(phone_number)
+    message_count = @redis.get("rate_limit:#{phone_number}").to_i
+    message_count >= (ENV['RATE_LIMIT'] || 5).to_i
+  end
+
+  def record_sent_message(phone_number)
+    key = "rate_limit:#{phone_number}"
+
+    # Redis will automatically expire the key after the specified time
+    @redis.multi do
+      @redis.incr(key) #increment the count
+      @redis.expire(key, (ENV['RATE_LIMIT_PERIOD'] || 3600).to_i) # Set to expire in 1 hour 
+    end
   end
 
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,11 @@
+if Rails.env.development? && ENV['START_REDIS'] != 'false'
+  begin
+    redis = Redis.new
+    redis.ping
+  rescue Errno::ECONNREFUSED
+    puts "Redis server not running, starting it now..."
+    # Start Redis server manually if it's not running
+    system("redis-server --daemonize yes")
+    sleep 2 # Wait for Redis to start
+  end
+end

--- a/spec/services/twilio_rate_limitng_spec.rb
+++ b/spec/services/twilio_rate_limitng_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe TwilioService, type: :service do
+  let(:twilio_service) { TwilioService.new }
+  let(:test_phone_number) { ENV['TEST_PHONE_NUMBER'] }
+  let(:phone_number) { '1234567890' }
+  let(:redis) { Redis.new }
+
+  before do
+    ENV['RATE_LIMIT_TEST_MODE'] = 'true'
+    print("Firing up Redis... #{redis.ping}")
+    redis.flushdb # Clear Redis cache
+  end
+
+  describe '#send_message' do
+    context 'when the rate limit is not exceeded' do
+      it 'sends a message and increments the Redis key' do
+        twilio_service.send_message(from: '5555555555', to: phone_number, body: 'Test')
+        expect(redis.get("rate_limit:#{phone_number}").to_i).to eq(1)
+      end
+    end
+
+    context 'when the rate limit is exceeded' do
+      before do
+        # Simulate that the recipient has already sent 5 messages in the past hour
+        5.times { twilio_service.send_message(from: '5555555555', to: phone_number, body: 'Test') }
+      end
+
+      it 'raises a rate limit error' do
+        allow(twilio_service).to receive(:send_message).and_raise('Rate limit exceeded')
+        expect { twilio_service.send_message(from: '5555555555', to: phone_number, body: 'Test') }
+          .to raise_error('Rate limit exceeded')
+      end
+    end
+  end
+end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe TwilioService, type: :service do
   let(:twilio_service) { TwilioService.new }
   let(:test_phone_number) { ENV['TEST_PHONE_NUMBER'] }
+  let(:phone_number) { '1234567890' }
 
   before do
-    # This is a Stub, Twilio client does not actually try to send an SMS here
+    # Stub the Twilio API call to avoid sending real messages
     allow(twilio_service).to receive(:send_message).and_return(double('Message', sid: 'fake_sid'))
   end
 
@@ -18,7 +19,6 @@ RSpec.describe TwilioService, type: :service do
           body: 'TEST MESSAGE: This is a test message from your Twilio integration.'
         )
 
- 
         twilio_service.send_test_message
       end
     end


### PR DESCRIPTION
**Why?**
- Need to rate limit Twilio SMS messaging
- I don't want to go broke! 
- We control this by count, time and on the individual user
- Make Redis automatically fire up, it's annoying...
**What?**
- Added Redis
- Updated Readme file
- Test mode for Testing Rate limiting
- Global vars for Test mode, Rate limit, and rate limit time period
- Global var to auto start Redis with rails console
- Redis to Rails console in Development environment, should auto-fire up now
- New  Rspec test suite for rate limiting Twilio Service

**Notes**
- Might want to implement a global rate limit ?
- Might want to add Redis to under environments...